### PR TITLE
Refactor Arguments to reduce repetition

### DIFF
--- a/Arguments.kt
+++ b/Arguments.kt
@@ -5,55 +5,42 @@ import java.io.File
 data class Arguments(val mode: (Algorithm, String, Int) -> String, val key: Int, val data: String, val alg: Algorithm, val out: File?)
 
 fun parseArgs(args: Array<String>): Arguments {
-    val modeIndex = args.indexOf("-mode")
-    val mode = when {
-        modeIndex < 0 -> DefaultMode
-        modeIndex == args.lastIndex -> DefaultMode
-        args[modeIndex + 1].startsWith("-") -> DefaultMode
-        args[modeIndex + 1] == "enc" -> DefaultMode
-        args[modeIndex + 1] == "dec" -> Algorithm::decrypt
-        else -> throw IllegalArgumentException("Error: mode must be 'enc' or 'dec'")
+
+    fun <T>fetchValueByName(name: String, default: T, defaultId: String? = null, decode: (String) -> T): T {
+        val index = args.indexOf("-$name")
+        val value = args.getOrNull(index + 1)
+        return when {
+            index < 0 || value == null || value.startsWith("-") || value == defaultId  -> default
+            else -> decode(value)
+        }
     }
 
-    val keyIndex = args.indexOf("-key")
-    val key = when {
-        keyIndex < 0 -> DefaultKey
-        keyIndex == args.lastIndex -> DefaultKey
-        args[keyIndex + 1].startsWith("-") -> DefaultKey
-        else -> try {
-            args[keyIndex + 1].toInt()
+    val mode = fetchValueByName("mode", DefaultMode, "enc") {
+        when (it) {
+            "dec" -> Algorithm::decrypt
+            else -> throw IllegalArgumentException("Error: mode must be 'enc' or 'dec'")
+        }
+    }
+
+    val key = fetchValueByName("key", DefaultKey) {
+        try {
+            it.toInt()
         } catch (e: NumberFormatException) {
             throw IllegalArgumentException("Error: key must be a number")
         }
     }
 
-    val dataIndex = args.indexOf("-data")
-    var data = DefaultData
-    if (dataIndex >= 0 && dataIndex < args.lastIndex) {
-        data = args[dataIndex + 1]
-    } else {
-        val inputIndex = args.indexOf("-in")
-        if (inputIndex >= 0 && inputIndex < args.lastIndex) {
-            val filename = args[inputIndex + 1]
-            data = File(filename).readText()
+    val data = fetchValueByName("data", DefaultData) { data ->
+        fetchValueByName("in", null) { filename -> File(filename).readText() } ?: data
+    }
+
+    val out = fetchValueByName("out", null) { filename -> File(filename) }
+
+    val alg = fetchValueByName("alg", DefaultAlgorithm, "shift") {
+        when (it) {
+            "unicode" -> Algorithm.Unicode
+            else -> throw IllegalArgumentException("Error: algorithm must be 'shift' or 'unicode'")
         }
-    }
-
-    val outIndex = args.indexOf("-out")
-    var out: File? = null
-    if (outIndex >= 0 && outIndex < args.lastIndex) {
-        val filename = args[outIndex + 1]
-        out = File(filename)
-    }
-
-    val algIndex = args.indexOf("-alg")
-    val alg = when {
-        algIndex < 0 -> DefaultAlgorithm
-        algIndex == args.lastIndex -> DefaultAlgorithm
-        args[algIndex + 1].startsWith("-") -> DefaultAlgorithm
-        args[algIndex + 1] == "shift" -> DefaultAlgorithm
-        args[algIndex + 1] == "unicode" -> Algorithm.Unicode
-        else -> throw IllegalArgumentException("Error: algorithm must be 'shift' or 'unicode'")
     }
 
     return Arguments(mode, key, data, alg, out)

--- a/Arguments.kt
+++ b/Arguments.kt
@@ -30,9 +30,9 @@ fun parseArgs(args: Array<String>): Arguments {
         }
     }
 
-    val data = fetchValueByName("data", DefaultData) { data ->
-        fetchValueByName("in", null) { filename -> File(filename).readText() } ?: data
-    }
+    val input = fetchValueByName("in", null) { filename -> File(filename).readText() }
+
+    val data = fetchValueByName("data", input ?: DefaultData) { it }
 
     val out = fetchValueByName("out", null) { filename -> File(filename) }
 

--- a/ArgumentsKtTest.kt
+++ b/ArgumentsKtTest.kt
@@ -1,0 +1,89 @@
+package encryptdecrypt
+
+import java.io.File
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+internal class ArgumentsKtTest {
+
+    @Test
+    fun `parseArgs for shift`() {
+        assertEquals(
+            Arguments(
+                mode = DefaultMode,
+                key = 5,
+                data = "Welcome to hyperskill!",
+                alg = Algorithm.Shift,
+                out = null
+            ),
+            parseArgs(
+                arrayOf("-key", "5", "-alg", "shift", "-data", "Welcome to hyperskill!", "-mode", "enc")
+            )
+        )
+        assertEquals(
+            Arguments(
+                mode = Algorithm::decrypt,
+                key = 5,
+                data = "Bjqhtrj yt mdujwxpnqq!",
+                alg = Algorithm.Shift,
+                out = null
+            ),
+            parseArgs(
+                arrayOf("-key", "5", "-alg", "shift", "-data", "Bjqhtrj yt mdujwxpnqq!", "-mode", "dec")
+            )
+        )
+        assertEquals(
+            Arguments(
+                mode = Algorithm::decrypt,
+                key = 5,
+                data = "Bjqhtrj yt mdujwxpnqq!",
+                alg = Algorithm.Shift,
+                out = File("dummy.txt")
+            ),
+            parseArgs(
+                arrayOf("-key", "5", "-alg", "shift", "-data", "Bjqhtrj yt mdujwxpnqq!", "-mode", "dec", "-out", "dummy.txt")
+            )
+        )
+    }
+    @Test
+
+    fun `parseArgs for unicode`() {
+        assertEquals(
+            Arguments(
+                mode = DefaultMode,
+                key = 5,
+                data = "Welcome to hyperskill!",
+                alg = Algorithm.Unicode,
+                out = null
+            ),
+            parseArgs(
+                arrayOf("-mode", "enc", "-key", "5", "-data", "Welcome to hyperskill!", "-alg", "unicode")
+            )
+        )
+        assertEquals(
+            Arguments(
+                mode = Algorithm::decrypt,
+                key = 5,
+                data = "\\jqhtrj%yt%m~ujwxpnqq&",
+                alg = Algorithm.Unicode,
+                out = null
+            ),
+            parseArgs(
+                arrayOf("-key", "5", "-alg", "unicode", "-data", "\\jqhtrj%yt%m~ujwxpnqq&", "-mode", "dec")
+            )
+        )
+        assertEquals(
+            Arguments(
+                mode = Algorithm::decrypt,
+                key = 5,
+                data = "\\jqhtrj%yt%m~ujwxpnqq&",
+                alg = Algorithm.Unicode,
+                out = File("dummy.txt")
+            ),
+            parseArgs(
+                arrayOf("-key", "5", "-alg", "unicode", "-data", "\\jqhtrj%yt%m~ujwxpnqq&", "-mode", "dec", "-out", "dummy.txt")
+            )
+        )
+    }
+}


### PR DESCRIPTION
Refactor `parseArgs` to reduce repetition (DRY principle). This will also allow the introduction of new command line parameters with ease.